### PR TITLE
Import hull prefab and animate track bones

### DIFF
--- a/UTanks-Online/Assets/ClientView/Scripts/Model/Game/Controllers/IHullVisualController.cs
+++ b/UTanks-Online/Assets/ClientView/Scripts/Model/Game/Controllers/IHullVisualController.cs
@@ -26,6 +26,8 @@ namespace SecuredSpace.ClientControl.Model
 
         public Vector3 localMountPoint = Vector3.zero;
         public Vector2 TrackTextureOffset = Vector2.zero;
+        public List<Transform> TrackBones = new List<Transform>();
+        public List<Transform> WheelBones = new List<Transform>();
         public AudioAnchor hullAudio => parentTankManager.hullAudioSource;
 
         private GameObject CacheTankFrictionCollidersObject;


### PR DESCRIPTION
## Summary
- Instantiate full hull prefab instead of only extracting meshes
- Auto-discover track and wheel bones and drive them during move animation
- Expose bone lists on hull visual controller for integration

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899ea8bacd08331896fcf1b377ebcf0