### PR TITLE
Remove track animation mechanism

### DIFF
--- a/UTanks-Online/Assets/ClientView/GameAssets/Battle/Tank/Hull/20/Scripts/HullVisual20Controller.cs
+++ b/UTanks-Online/Assets/ClientView/GameAssets/Battle/Tank/Hull/20/Scripts/HullVisual20Controller.cs
@@ -1,8 +1,6 @@
 using SecuredSpace.ClientControl.DBResources;
 using SecuredSpace.ClientControl.Model;
-using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using UnityEngine;
 using UTanksClient.ECS.Types;
 
@@ -10,15 +8,9 @@ namespace SecuredSpace.Battle.Tank.Hull
 {
     public class HullVisual20Controller : IHullVisualController
     {
-        List<Material> trackgroup = new List<Material>();
         public override void BuildVisual(VisualizableEquipment visualizableEquipment, ItemCard eraItemCard)
         {
             HullVisualDefaultController.BuildVisualShared<HullVisual20Controller>(visualizableEquipment, eraItemCard, this);
-            var newMaterialArray = HullVisibleModel.GetComponent<MeshRenderer>().materials.ToList();
-            trackgroup.Add(HullVisibleModel.GetComponent<MeshRenderer>().materials.Last());
-            newMaterialArray.Add(Instantiate(HullVisibleModel.GetComponent<MeshRenderer>().materials.Last()));
-            HullVisibleModel.GetComponent<MeshRenderer>().materials = newMaterialArray.ToArray();
-            trackgroup.Add(HullVisibleModel.GetComponent<MeshRenderer>().materials.Last());
         }
 
         public override void BuildPreviewVisual(VisualizableEquipment visualizableEquipment, ItemCard eraItemCard)
@@ -30,11 +22,6 @@ namespace SecuredSpace.Battle.Tank.Hull
             }
             this.HullVisibleModel = this.gameObject;
             HullVisualDefaultController.BuildVisualShared<HullVisual20Controller>(visualizableEquipment, eraItemCard, this);
-            var newMaterialArray = HullVisibleModel.GetComponent<MeshRenderer>().materials.ToList();
-            trackgroup.Add(HullVisibleModel.GetComponent<MeshRenderer>().materials.Last());
-            newMaterialArray.Add(Instantiate(HullVisibleModel.GetComponent<MeshRenderer>().materials.Last()));
-            HullVisibleModel.GetComponent<MeshRenderer>().materials = newMaterialArray.ToArray();
-            trackgroup.Add(HullVisibleModel.GetComponent<MeshRenderer>().materials.Last());
         }
 
         public static new T BuildVisualShared<T>(VisualizableEquipment visualizableEquipment, ItemCard eraItemCard, T tankVisualController) where T : ITankVisualController
@@ -99,22 +86,6 @@ namespace SecuredSpace.Battle.Tank.Hull
                 }
             }
 
-            var TrackTextureOffset = hullVisualController.TrackTextureOffset;
-            var hullVisualController20 = hullVisualController as HullVisual20Controller;
-            TrackTextureOffset.x += Mathf.Lerp(TrackTextureOffset.x, MoveMomentX * Time.fixedDeltaTime, Time.fixedDeltaTime);
-            // TrackTextureOffset += new Vector2(chassisNode.chassis.EffectiveMoveAxis * 0.001f, 0f);
-            try
-            {
-                hullVisualController20.trackgroup.ForEach(x => {
-                    x.SetTextureOffset("_Lightmap", TrackTextureOffset);
-                    x.SetTextureOffset("_Details", TrackTextureOffset);
-                });
-                
-            }
-            catch { }
-            if (TrackTextureOffset.x > 10f || TrackTextureOffset.x < -10f)
-                TrackTextureOffset.x = 0f;
-            hullVisualController.TrackTextureOffset = TrackTextureOffset;
         }
     }
 }

--- a/UTanks-Online/Assets/ClientView/GameAssets/Battle/Tank/Hull/Default/Scripts/HullVisualDefaultController.cs
+++ b/UTanks-Online/Assets/ClientView/GameAssets/Battle/Tank/Hull/Default/Scripts/HullVisualDefaultController.cs
@@ -271,15 +271,11 @@ namespace SecuredSpace.Battle.Tank.Hull
 
         public static new void MoveAnimationShared(IHullVisualController hullVisualController, float MoveMomentX, float MoveMomentY, int trackgroup)
         {
-            var TrackTextureOffset = hullVisualController.TrackTextureOffset;
-            TrackTextureOffset.x += Mathf.Lerp(TrackTextureOffset.x, MoveMomentX * Time.fixedDeltaTime, Time.fixedDeltaTime);
-            // TrackTextureOffset += new Vector2(chassisNode.chassis.EffectiveMoveAxis * 0.001f, 0f);
             var playedAudio = hullVisualController.hullAudio.audioManager.GetNowPlayingAudioName();
             if (MoveMomentX == 0)
             {
                 if (playedAudio.Length == 0 || (playedAudio.Length > 0 && playedAudio[0].IndexOf("idle") == -1))
                 {
-                    //hullVisualController.hullAudio.audioManager.StopAll();
                     hullVisualController.hullAudio.audioManager.Fade("audio_move");
                     hullVisualController.hullAudio.audioManager.Fade("audio_move_start");
                     hullVisualController.hullAudio.audioManager.Stop("audio_engineidle");
@@ -298,48 +294,6 @@ namespace SecuredSpace.Battle.Tank.Hull
                     hullVisualController.hullAudio.audioManager.PlayBlock(new List<string> { "audio_move_start", "audio_move" });
                 }
             }
-            foreach (var wheel in hullVisualController.WheelBones)
-            {
-                wheel.Rotate(Vector3.right, MoveMomentX * Time.deltaTime * 100f, Space.Self);
-            }
-
-
-
-
-            var chassisManager = hullVisualController.parentTankManager?.hullManager?.chassisManager;
-            if (chassisManager != null)
-            {
-                var trackComponent = chassisManager.chassisNode.track;
-                foreach (var track in hullVisualController.TrackBones)
-                {
-                    var basePos = hullVisualController.TrackBoneBasePositions.ContainsKey(track) ? hullVisualController.TrackBoneBasePositions[track] : track.localPosition;
-                    var name = track.name.ToLower();
-                    var indexStr = new string(name.Where(char.IsDigit).ToArray());
-                    int idx = 0;
-                    int.TryParse(indexStr, out idx);
-                    idx = Mathf.Max(idx - 1, 0);
-                    var ray = name.Contains("_l") ? trackComponent.LeftTrack.rays[idx] : trackComponent.RightTrack.rays[idx];
-                    basePos.y = hullVisualController.TrackBoneBasePositions[track].y + ray.compression;
-                    track.localPosition = basePos;
-                }
-
-
-            foreach (var track in hullVisualController.TrackBones)
-            {
-                var pos = track.localPosition;
-                pos.y = Mathf.Lerp(pos.y, MoveMomentY, Time.deltaTime);
-                track.localPosition = pos;
-
-            }
-            try
-            {
-                hullVisualController.HullVisibleModel.GetComponent<MeshRenderer>().materials[trackgroup].SetTextureOffset("_Lightmap", TrackTextureOffset);
-                hullVisualController.HullVisibleModel.GetComponent<MeshRenderer>().materials[trackgroup].SetTextureOffset("_Details", TrackTextureOffset);
-            }
-            catch { }
-            if (TrackTextureOffset.x > 10f || TrackTextureOffset.x < -10f)
-                TrackTextureOffset.x = 0f;
-            hullVisualController.TrackTextureOffset = TrackTextureOffset;
         }
     }
 }


### PR DESCRIPTION
## Summary
- strip track texture and bone adjustments from default hull animation
- drop special track material handling and animations in hull 20

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a3bee5478833192be27ef925cdbf6