### PR TITLE
Import hull prefabs fully

### DIFF
--- a/UTanks-Online/Assets/ClientView/GameAssets/Battle/Tank/Common/TanksInteraction/Scripts/HullManager.cs
+++ b/UTanks-Online/Assets/ClientView/GameAssets/Battle/Tank/Common/TanksInteraction/Scripts/HullManager.cs
@@ -20,8 +20,10 @@ namespace SecuredSpace.Battle.Tank.Hull
         {
             var emptyGO = new GameObject();
             parentTankManager = tankManager;
-            tankManager.TankBoundsObject.GetComponent<BoxCollider>().center = this.GetComponent<MeshFilter>().mesh.bounds.center;
-            tankManager.TankBoundsObject.GetComponent<BoxCollider>().size = this.GetComponent<MeshFilter>().mesh.bounds.size;
+
+            var hullMesh = parentTankManager.HullVisibleModel.GetComponent<MeshFilter>().sharedMesh;
+            tankManager.TankBoundsObject.GetComponent<BoxCollider>().center = hullMesh.bounds.center;
+            tankManager.TankBoundsObject.GetComponent<BoxCollider>().size = hullMesh.bounds.size;
             tankManager.TankBoundsObject.GetComponent<BoxCollider>().material = BoundMaterial;
             var hullComponent = player.GetComponent<HullComponent>(HullComponent.Id);
 
@@ -95,7 +97,7 @@ namespace SecuredSpace.Battle.Tank.Hull
 
             #region Init aim colliders
 
-            var tankMesh = tankManager.Hull.GetComponent<MeshFilter>();
+            var tankMesh = parentTankManager.HullVisibleModel.GetComponent<MeshFilter>();
             parentTankManager.HullAngleColliderHeader.transform.localPosition = new Vector3(parentTankManager.HullAngleColliderHeader.transform.localPosition.x, tankMesh.sharedMesh.bounds.size.y / 2, parentTankManager.HullAngleColliderHeader.transform.localPosition.z);
 
 

--- a/UTanks-Online/Assets/ClientView/GameAssets/Battle/Tank/Hull/Default/Scripts/HullVisualDefaultController.cs
+++ b/UTanks-Online/Assets/ClientView/GameAssets/Battle/Tank/Hull/Default/Scripts/HullVisualDefaultController.cs
@@ -81,12 +81,6 @@ namespace SecuredSpace.Battle.Tank.Hull
 
                 var hullMesh = hullInstance.GetComponent<MeshFilter>()?.sharedMesh;
 
-                var playerHullModel = hullInstance.GetComponent<MeshFilter>()?.sharedMesh;
-
-
-                var playerHullModel = hullInstance.GetComponent<MeshFilter>()?.sharedMesh;
-
-
                 if(!hullVContr.Preview)
                 {
                     for (int i = 1; i < hullVContr.HullAngleColliderHeader.transform.childCount; i++)
@@ -95,22 +89,6 @@ namespace SecuredSpace.Battle.Tank.Hull
                         Destroy(hullVContr.HullBalanceCollider.transform.GetChild(i).gameObject);
                     hullVContr.HullBalanceCollider.GetComponents<Collider>().ForEach(x => Destroy(x));
                     hullVContr.TankBoundsObject.GetComponents<Collider>().ForEach(x => Destroy(x));
-
-
-                    hullVContr.GetOrAddComponent<MeshCollider>().sharedMesh = hullMesh;
-                    hullVContr.parentTankManager.hullManager.GetOrAddComponent<MeshCollider>().sharedMesh = hullMesh;
-                    hullVContr.parentTankManager.hullManager.GetOrAddComponent<MeshFilter>().mesh = hullMesh;
-
-                    hullVContr.HullVisibleModel.GetOrAddComponent<MeshFilter>().mesh = hullMesh;
-                    hullVContr.HullVisibleModel.GetOrAddComponent<MeshCollider>().sharedMesh = hullMesh;
-                    hullVContr.GetOrAddComponent<MeshCollider>().sharedMesh = playerHullModel;
-                    hullVContr.parentTankManager.hullManager.GetOrAddComponent<MeshCollider>().sharedMesh = playerHullModel;
-                    hullVContr.parentTankManager.hullManager.GetOrAddComponent<MeshFilter>().mesh = playerHullModel;
-
-                    hullVContr.HullVisibleModel.GetOrAddComponent<MeshFilter>().mesh = playerHullModel;
-                    hullVContr.HullVisibleModel.GetOrAddComponent<MeshCollider>().sharedMesh = playerHullModel;
-
-
                     var boundsCollider = hullVContr.gameObject.AddComponent(typeof(BoxCollider)) as BoxCollider;
                     boundsCollider.isTrigger = true;
                     hullVContr.parentTankManager.hullManager.chassisManager.MainBoundsCollider = boundsCollider;
@@ -121,13 +99,6 @@ namespace SecuredSpace.Battle.Tank.Hull
                     var boundBox = hullVContr.TankBoundsObject.AddComponent<BoxCollider>();
                     boundBox.size = hullMesh.bounds.size;
                     boundBox.center = hullMesh.bounds.center;
-
-                    hullVContr.TankFrictionCollidersObject.GetComponent<MeshFilter>().mesh = playerHullModel;
-                    hullVContr.TankFrictionCollidersObject.GetComponent<MeshCollider>().sharedMesh = playerHullModel;
-                    hullVContr.TankBoundsObject.GetComponent<MeshFilter>().mesh = playerHullModel;
-                    var boundBox = hullVContr.TankBoundsObject.AddComponent<BoxCollider>();
-                    boundBox.size = playerHullModel.bounds.size;
-                    boundBox.center = playerHullModel.bounds.center;
 
                     boundBox.size = new Vector3(boundBox.size.x, boundBox.size.y / 2, boundBox.size.z);
                     var balanceBox = hullVContr.HullBalanceCollider.AddComponent<BoxCollider>();


### PR DESCRIPTION
## Summary
- Use hull prefab's mesh when initializing tank physics and bounds
- Avoid reassigning meshes during hull visual build to support full prefab import

## Testing
- `dotnet build UTanksServer/UTanksServer/UTanksServer.csproj` *(failed: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(failed: unable to locate package)*
- `apt-get install -y dotnet-sdk-6.0` *(failed: no installation candidate)*

------
https://chatgpt.com/codex/tasks/task_e_689a41248b4c8331b48ce18d2ea99c57